### PR TITLE
✨ Add ability to add, update, and delete lists in the web interface

### DIFF
--- a/src/appdb.py
+++ b/src/appdb.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from flask import Flask, render_template
+from flask import Flask, render_template, session
 from .api import api as api_blueprint
 from .userland import userland as userland_blueprint
 from .developer import developer as developer_blueprint
@@ -24,6 +24,10 @@ with app.app_context():
     app.register_blueprint(developer_blueprint)
     app.register_blueprint(auth_blueprint)
     app.register_blueprint(curator_blueprint)
+
+@app.before_request
+def register_session():
+    session.permanent = True
 
 @app.after_request
 def after_request(response):

--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from os import getenv, urandom
+from os import getenv
 from dotenv import load_dotenv
 
 load_dotenv(".env")
@@ -20,4 +20,4 @@ PSQL_HOST = getenv("PSQL_HOST")
 GH_CLIENT_ID = getenv("GH_CLIENT_ID")
 GH_CLIENT_SECRET = getenv("GH_CLIENT_SECRET")
 
-SECRET_KEY = urandom(16)
+SECRET_KEY = "cnh3X2lkZW50aWZpZWRfY2VydGlmaWNhdGUK"

--- a/src/curator.py
+++ b/src/curator.py
@@ -5,16 +5,73 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https: //mozilla.org/MPL/2.0/.
 
-from flask import Blueprint, render_template, jsonify, request, redirect, abort, session
+from flask import Blueprint, render_template, jsonify, request, abort, session
+from flask.helpers import url_for
+from werkzeug.utils import redirect
 from .database import connect_database
 from . import roland as ro
 
 curator = Blueprint("curator", __name__, template_folder="../templates", static_folder="../static", url_prefix="/curator")
 
-
-@curator.route("/curator/dashboard")
-def cur_dashboard():
+def _verify_curator():
+    """Verify that the currently logged-in user is indeed a curator."""
     acct = ro.accounts.get_account(connect_database(), session.get("cuid"))
     if not acct or acct["accounttype"] != ro.accounts.AccountType.Curator:
         abort(401)
-    return "200", 200
+    return acct
+
+@curator.route("/dashboard")
+def cur_dashboard():
+    account = _verify_curator()
+    return render_template("pages/curator/dashboard.html", curator=account), 200
+
+@curator.route("/lists")
+def lists_dashboard():
+    _verify_curator()
+    cur_lists = ro.lists.get_curator_lists(connect_database(), session.get("cuid"))
+    apps = {}
+    for list in cur_lists:
+        apps[list["listid"]] = ro.lists.get_projects_from_list(connect_database(), list["listid"])
+    return render_template("pages/curator/lists_dashboard.html", lists=cur_lists, projs=apps), 200
+
+@curator.route("/lists/create")
+def create_list():
+    _verify_curator()
+    all_apps = ro.projects.list_projects(connect_database())
+    return render_template("pages/curator/wizard.html", projects=all_apps), 200
+
+@curator.route("/lists/add", methods=["GET", "POST"])
+def create_list_request():
+    _verify_curator()
+    all_projects_for_list = request.form.getlist("projects") if "projects" in request.form else None
+    list_id = ro.lists.create_list(
+        connect_database(), request.form["name"], request.form["blurb"], all_projects_for_list, session.get("cuid"))
+    
+    if not list_id:
+        abort(500)
+    return redirect(url_for('curator.lists_dashboard')), 200
+
+@curator.route("/lists/<int:list_id>/manage")
+def manage_list(list_id: int):
+    edited_list = ro.lists.get_one_list(connect_database(), str(list_id))
+    return render_template("pages/curator/list_manager.html", list=edited_list), 200
+
+@curator.route("/lists/update", methods=["GET", "POST"])
+def update_list_request():
+    _verify_curator()
+    try:
+        ro.lists.update_list(connect_database(), request.form["id"], request.form["name"], request.form["blurb"])
+        return redirect(url_for('curator.lists_dashboard'))
+    except Exception as error:
+        print(error)
+        abort(500)
+
+@curator.route("/lists/delete", methods=["GET", "POST"])
+def delete_list_request():
+    _verify_curator()
+    try:
+        ro.lists.delete_list(connect_database(), request.form["id"])
+        return redirect(url_for('curator.lists_dashboard')), 200
+    except Exception as error:
+        print(error)
+        abort(500)

--- a/src/roland/lists.py
+++ b/src/roland/lists.py
@@ -44,3 +44,39 @@ def get_projects_from_list(in_app_db, list_id: str) -> list:
         command = SQL("select * from (Project join Includes using (projectId)) where listId = %s")
         cursor.execute(command, [list_id])
         return [_transform_project_data(s, in_app_db) for s in cursor.fetchall()]
+
+def create_list(in_app_db, list_name: str, list_blurb: str, list_apps, with_curator: str):
+    projects = list_apps if list_apps else []
+    with DatabaseContext(in_app_db, cursor_factory=RealDictCursor) as cursor:
+        spawner = SQL("insert into List (name, blurb, userId) values (%s, %s, %s)")
+        cursor.execute(spawner, [list_name, list_blurb, with_curator])
+
+        new_id_finder = SQL("select listId from List where name = %s and userId = %s")
+        cursor.execute(new_id_finder, [list_name, with_curator])
+
+        new_id = cursor.fetchone()
+        if new_id:
+            for project in projects:
+                command = SQL("insert into Includes values (%s, %s)")
+                cursor.execute(command, [new_id["listid"], project])
+        
+        in_app_db.commit()
+        return new_id.listid
+
+def update_list(in_app_db, list_id, new_name, new_blurb):
+    with DatabaseContext(in_app_db) as cursor:
+        command = SQL("update List set name = %s, blurb = %s where listId = %s")
+        cursor.execute(command, [new_name, new_blurb, list_id])
+        in_app_db.commit()
+
+
+def delete_list(in_app_db, list_id):
+    projects_in_list = get_projects_from_list(in_app_db, list_id)
+    with DatabaseContext(in_app_db, cursor_factory=RealDictCursor) as cursor:
+        for project in projects_in_list:
+            deletor = SQL("delete from Includes where projectId = %s and listId = %s")
+            cursor.execute(deletor, [project["id"], list_id])
+        
+        deletor_list = SQL("delete from List where listId = %s")
+        cursor.execute(deletor_list, [list_id])
+        in_app_db.commit()

--- a/static/js/vanilla.js
+++ b/static/js/vanilla.js
@@ -2,6 +2,29 @@
 // Licensed under LGPL-3.0.
 
 /**
+  Toggles visibility of modal dialog.
+  @param {HTMLElement} modal Modal dialog to show or hide.
+*/
+function toggleModal(modal) {
+  if (modal && modal.classList.contains('p-modal')) {
+    if (modal.style.display === 'none') {
+      modal.style.display = 'flex';
+      modal.focus();
+    } else {
+      modal.style.display = 'none';
+    }
+  }
+}
+
+// Add click handler for clicks on elements with aria-controls
+document.addEventListener('click', function (event) {
+  var targetControls = event.target.getAttribute('aria-controls');
+  if (targetControls) {
+    toggleModal(document.getElementById(targetControls));
+  }
+});
+
+/**
      Toggles visibility of given subnav by toggling is-active class to it
     and setting aria-hidden attribute on dropdown contents.
     @param {HTMLElement} subnav Root element of subnavigation to open.

--- a/templates/pages/curator/dashboard.html
+++ b/templates/pages/curator/dashboard.html
@@ -1,0 +1,15 @@
+{% extends "default.html" %}
+{% block title %}My Dashboard - Candella AppDB {% endblock %}
+{% block content %}
+<div class="p-strip--suru-topped">
+    <div class="row">
+        <h1>Howdy, {{ curator.name }}.</h1>
+        <p>
+            You currently have no projects waiting for inspection in the queue.
+        </p>
+        <p>
+            <a class="p-button" href="{{ url_for('curator.lists_dashboard') }}">Manage my lists</a>
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/templates/pages/curator/list_manager.html
+++ b/templates/pages/curator/list_manager.html
@@ -1,0 +1,54 @@
+{% extends "default.html" %}
+{% block title %}Manage '{{ list.name }}' - Candella AppDB{% endblock %}
+{% block content %}
+<div class="p-strip--suru-topped">
+    <div class="row">
+        <p><a class="p-button" href="{{ url_for('curator.lists_dashboard') }}">&lsaquo; Back to lists</a></p>
+        <h2>Manage list</h2>
+        <p>
+            Use the form below to update details about this list. To add or remove projects from this list,
+            delete the list and then create a new list with the updated projects list.
+        </p>
+    </div>
+    <div class="row">
+        <div class="col-10">
+            <form action="{{ url_for('curator.update_list_request') }}" method="POST">
+                <label for="newListName">List name</label>
+                <input type="hidden" name="id" value="{{ list.listid }}"/>
+                <input type="text" name="name" id="newListName" placeholder="List name" value="{{ list.name }}">
+
+                <label for="newListBlurb">What makes this list special?</label>
+                <textarea id="listBlurb" name="blurb" rows="8">{{ list.blurb }}</textarea>
+                <button class="p-button--positive" type="submit">Update list</button>
+            </form>
+        </div>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="row">
+        <h3>Delete list</h3>
+        <p>
+            Deleting this list will remove it from the curator list catalog and remove any associations
+            a project has with this list. <i>This action cannot be undone.</i>
+        </p>
+        <p><button class="p-button--negative" id="showModal" aria-controls="modal">Delete…</button></p>
+        
+    </div>
+</div>
+<div class="p-modal" id="modal" style="display: none;">
+    <section class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+        <header class="p-modal__header">
+            <h2 class="p-modal__title" id="modal-title">Confirm delete</h2>
+            <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
+        </header>
+        <p>Are you sure you want to delete the list "{{ list.name }}"? This action is permanent and cannot be undone.</p>
+        <footer class="p-modal__footer">
+            <form action="{{ url_for('curator.delete_list_request', list_id=list.listid) }}" method="POST">
+                <input type="hidden" name="id" value="{{ list.listid }}">
+                <button class="u-no-margin--bottom" aria-controls="modal">Cancel</button>
+                <button type="submit" class="p-button--negative u-no-margin--bottom">Delete</button>
+            </form>
+        </footer>
+    </section>
+</div>
+{% endblock %}

--- a/templates/pages/curator/lists_dashboard.html
+++ b/templates/pages/curator/lists_dashboard.html
@@ -1,0 +1,32 @@
+{% extends "default.html" %}
+{% block title %}My Lists{% endblock %}
+{% block content %}
+<div class="p-strip--suru-topped">
+    <div class="row">
+        <p><a class="p-button" href="{{ url_for('curator.cur_dashboard') }}">&lsaquo; Back to dashboard</a></p>
+        <h2>My curated lists</h2>
+        <p>
+            Below is a list of all of the lists you're currently curating. Click "Add list"
+            to add a new list, or click "Manage" on any given list to edit its properties.
+        </p>
+        <p>
+            <a class="p-button--positive has-icon" href="{{ url_for('curator.create_list') }}">
+                <i class="p-icon--plus is-light"></i><span>Add list</span>
+            </a>
+        </p>
+    </div>
+</div>
+<div class="p-strip is-shallow">
+    {% for list in lists %}
+    <div class="row">
+        <h3>{{ list.name }}</h3>
+        <p class="u-text--muted">{{ projs[list.listid]|length }} projects total</p>
+        <p>{{ list.blurb | truncate(75) }}</p>
+        <p>
+            <a class="p-button" href="{{ url_for('curator.manage_list', list_id=list.listid) }}">Manage</a>
+            <a class="p-button" href="{{ url_for('userland.list_detail', id=list.listid) }}">View</a>
+        </p>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/templates/pages/curator/wizard.html
+++ b/templates/pages/curator/wizard.html
@@ -1,0 +1,38 @@
+{% extends "default.html" %}
+{% block title %}Create New List - Candella AppDB{% endblock %}
+{% block content %}
+<div class="p-strip--suru-topped">
+    <div class="row">
+        <p><a class="p-button" href="{{ url_for('curator.lists_dashboard') }}">&lsaquo; Back to lists</a></p>
+        <h2>Create a new list</h2>
+        <p>
+            Creating a new list will let users see recommended apps based on a specified criteria.
+            Criteria may vary based upon recency, category, or an editorial piece.
+        </p>
+    </div>
+    <div class="row">
+        <div class="col-10">
+            <form class="p-form p-form--stacked" action="{{ url_for('curator.create_list_request') }}" method="POST">
+                <label for="listName">List name</label>
+                <input type="text" name="name" id="listName" placeholder="My new list">
+
+                <label for="listBlurb">What's special about this list?</label>
+                <textarea id="listBlurb" name="blurb" rows="5"></textarea>
+                <fieldset>
+                    <label for="listApps">Which projects will be featured?</label>
+                    <select name="projects" id="listApps" multiple="">
+                        <option value="disabled" disabled="">Select projects...</option>
+                        {% for project in projects %}
+                        <option value="{{ project.id }}">{{ project.name }} <span class="u-text--muted">({{ project.id }})</span></option>
+                        {% endfor %}
+                    </select>
+                    <p class="u-text--muted">Note: Press Shift or Cmd/Ctrl to select multiple projects.</p>
+                </fieldset>
+                
+                <button class="p-button--positive" type="submit">Create</button>
+                <button type="reset">Reset</button>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
I've added most, if not all, of the functionality for curator lists as per our database specification:

- Creating lists with a name, blurb, and list of projects
- Updating that list's name and blurb
- Deleting a project and the project associations with it, respectively

The curator list pages have also been added to manage this through the web. I did not write APIs for this since we shouldn't expose creation/management yet until we have a means of authenticating API requests.