### PR TITLE
:wrench: Add deployment scripts for Heroku

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ psycopg2-binary = "*"
 passlib = "*"
 python-dotenv = "*"
 requests = "*"
+gunicorn = "*"
 
 [dev-packages]
 autopep8 = "*"

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn src.wsgi:app

--- a/src/wsgi.py
+++ b/src/wsgi.py
@@ -1,0 +1,11 @@
+# wsgi.py
+# (C) 2021 Marquis Kurt, Nodar Sotkilava, and Unscripted VN Team.
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https: //mozilla.org/MPL/2.0/.
+
+from .appdb import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
I've added support for deploying to Heroku with relative ease.

- Adds the `Procfile` needed to run the server
- Adds the `gunicorn` dependency to the project for Heroku
- Updates the source code with a `wsgi.py` file that gunicorn/Heroku reads